### PR TITLE
fix the secure connection problem

### DIFF
--- a/timeplus-native-jdbc/src/test/java/com/timeplus/jdbc/TimeplusConnectionITest.java
+++ b/timeplus-native-jdbc/src/test/java/com/timeplus/jdbc/TimeplusConnectionITest.java
@@ -14,8 +14,8 @@
 
 package com.timeplus.jdbc;
 
-// import com.timeplus.jdbc.tool.LocalKeyStoreConfig;
-// import com.timeplus.settings.KeyStoreConfig;
+import com.timeplus.jdbc.tool.LocalKeyStoreConfig;
+import com.timeplus.settings.KeyStoreConfig;
 import org.junit.jupiter.api.Test;
 
 import java.sql.ResultSet;
@@ -36,31 +36,29 @@ public class TimeplusConnectionITest extends AbstractITest {
 
     @Test
     void pingWithSecureConnection() throws Exception {
-        // FIXME
-        // withNewConnection(connection -> {
-        //             withStatement(connection, stmt -> {
-        //                 ResultSet resultSet = stmt.executeQuery("SELECT 1");
-        //                 assertTrue(resultSet.next());
-        //             });
-        //         }, "ssl", "true",
-        //         "ssl_mode", "disabled");
+        withNewConnection(connection -> {
+                    withStatement(connection, stmt -> {
+                        ResultSet resultSet = stmt.executeQuery("SELECT 1");
+                        assertTrue(resultSet.next());
+                    });
+                }, "ssl", "true",
+                "ssl_mode", "disabled");
     }
 
     @Test
     void pingWithSecureConnectionAndVerification() throws Exception {
-        // FIXME
-        //KeyStoreConfig keyStoreConfig = new LocalKeyStoreConfig();
+        KeyStoreConfig keyStoreConfig = new LocalKeyStoreConfig();
 
-        // withNewConnection(connection -> {
-        //             withStatement(connection, stmt -> {
-        //                 ResultSet resultSet = stmt.executeQuery("SELECT 1");
-        //                 assertTrue(resultSet.next());
-        //             });
-        //         }, "ssl", "true",
-        //         "ssl_mode", "verify_ca",
-        //         "key_store_type", keyStoreConfig.getKeyStoreType(),
-        //         "key_store_path", keyStoreConfig.getKeyStorePath(),
-        //         "key_store_password", keyStoreConfig.getKeyStorePassword());
+        withNewConnection(connection -> {
+                    withStatement(connection, stmt -> {
+                        ResultSet resultSet = stmt.executeQuery("SELECT 1");
+                        assertTrue(resultSet.next());
+                    });
+                }, "ssl", "true",
+                "ssl_mode", "verify_ca",
+                "key_store_type", keyStoreConfig.getKeyStoreType(),
+                "key_store_path", keyStoreConfig.getKeyStorePath(),
+                "key_store_password", keyStoreConfig.getKeyStorePassword());
     }
 
     @Test


### PR DESCRIPTION
close #39 
Find out the reason for connection failed problem. As long as we open the tls setting for the port and generate the key, we'll able to connect in secure mode.